### PR TITLE
templates: index.js: metrics url for fqdn

### DIFF
--- a/templates/index.js
+++ b/templates/index.js
@@ -1,3 +1,5 @@
+const KASPA_NG_URL = 'https://kaspa-ng.org/';
+
 document.addEventListener('DOMContentLoaded', () => {
     window.resolver = {
         sort : "network",
@@ -162,6 +164,7 @@ function render() {
         let peers_ = pad(peers.toLocaleString(),4);
         let clients_ = pad(clients.toLocaleString(),6);
         let capacity_ = pad(capacity.toLocaleString(),6);
+        fqdn = (status != "offline") ? `<a href=${KASPA_NG_URL}?wrpc=${url} target="_blank">${fqdn}</a>` : fqdn;
         el.innerHTML = `<td>${sid}:${uid}</td><td>${service}</td><td>${version}</td><td class='fqdn'>${fqdn}</td><td>${protocol}</td><td>${encoding}</td><td>${network}</td><td>${status}</td>`;
         if (status != "offline") {
             el.innerHTML += `<td class='wide right pre'>${peers_}</td><td class='wide right pre'>${clients_} / ${capacity_}</td><td class='wide right'>${load}%</td>`;


### PR DESCRIPTION
Change FQDN field, for online nodes, to be a link to kaspa-ng to view node metrics.